### PR TITLE
DIG-2005, DIG-2047: Save experiment metadata, save files once, add download results

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ candigv2-client [OUTPUT_TYPE] [FILTER]
 7. **Fetch all available data for donors that were treated with the drug `Durvalumab` (allowing for multiple case-sensitive options):**
 
     ```bash
-    candigv2-client-a --drug-name "Durvalumab" "durvalumab" --token YOUR_TOKEN
+    candigv2-client -a --drug-name "Durvalumab" "durvalumab" --token YOUR_TOKEN
     ```
 
 8. **Download all variants for all donors from all authorized programs within the `SLX9` gene:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "httpx",
     "tqdm",
-    "colorama",
+    "pandas",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 httpx
 tqdm
-colorama
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 httpx
 tqdm
 colorama
+pandas

--- a/src/client/download_helpers.py
+++ b/src/client/download_helpers.py
@@ -61,9 +61,9 @@ def calculate_checksum(file_path: Path, hash_type: str = "md5") -> Optional[str]
 
 
 def verify_local_file(
-    local_file_path: Path,
-    expected_size: Optional[int],
-    expected_checksums: List[Dict[str, str]],
+        local_file_path: Path,
+        expected_size: Optional[int],
+        expected_checksums: List[Dict[str, str]],
 ) -> Tuple[str, str]:
     """
     Verifies a local file against expected size and checksums.
@@ -151,9 +151,9 @@ def verify_local_file(
             "No checksums or size provided in metadata for validation.",
         )
     elif (
-        expected_checksums
-        and not has_verifiable_checksum_type_in_metadata
-        and expected_size is None
+            expected_checksums
+            and not has_verifiable_checksum_type_in_metadata
+            and expected_size is None
     ):
         return (
             "NO_VALIDATION_CRITERIA",
@@ -164,10 +164,10 @@ def verify_local_file(
 
 
 def execute_federation_call(
-    federation_url: str,
-    headers: Dict[str, str],
-    payload: Dict[str, Any],
-    progress_callback: Optional[callable] = None,
+        federation_url: str,
+        headers: Dict[str, str],
+        payload: Dict[str, Any],
+        progress_callback: Optional[callable] = None,
 ) -> Optional[List[Dict[str, Any]]]:
     """
     Makes a POST request to the federation endpoint.
@@ -212,11 +212,11 @@ def execute_federation_call(
 
 
 def download_file(
-    url: str,
-    headers: Dict[str, str],
-    output_dir: Path,
-    filename: str,
-    show_progress: bool = True,
+        url: str,
+        headers: Dict[str, str],
+        output_dir: Path,
+        filename: str,
+        show_progress: bool = True,
 ) -> DownloadResult:
     """Download a file from a URL."""
     try:
@@ -224,7 +224,7 @@ def download_file(
         logger.debug(f"Downloading from url {url} to {output_path}")
 
         with httpx.stream(
-            "GET", url, headers=headers, timeout=config.TIMEOUT
+                "GET", url, headers=headers, timeout=config.TIMEOUT
         ) as response:
             response.raise_for_status()
             total_size = int(response.headers.get("content-length", 0))
@@ -232,12 +232,12 @@ def download_file(
             with open(output_path, "wb") as f:
                 if show_progress and total_size > 0:
                     with tqdm(
-                        total=total_size,
-                        unit="iB",
-                        unit_scale=True,
-                        desc=f" {filename[:25]:<25}..",
-                        leave=False,
-                        position=1,
+                            total=total_size,
+                            unit="iB",
+                            unit_scale=True,
+                            desc=f" {filename[:25]:<25}..",
+                            leave=False,
+                            position=1,
                     ) as pbar:
                         for chunk in response.iter_raw():
                             size = f.write(chunk)
@@ -307,7 +307,7 @@ def should_skip_file(drs_object_results: Dict[str, Any]) -> tuple[bool, Optional
 
 
 def extract_file_metadata_from_drs_results(
-    drs_object_results: Dict[str, Any], target_relative_dir: Path
+        drs_object_results: Dict[str, Any], target_relative_dir: Path
 ) -> Dict[str, Any]:
     """
     Extracts metadata needed for download from a DRS objects results field.
@@ -359,12 +359,12 @@ def extract_file_metadata_from_drs_results(
 
 
 def collect_metadata_for_file_item(
-    file_item_info: Dict[str, Any],
-    file_type_label: str,
-    federation_headers: Dict[str, str],
-    federation_url: str,
-    target_relative_dir: Path,
-    is_dry_run: bool = False,
+        file_item_info: Dict[str, Any],
+        file_type_label: str,
+        federation_headers: Dict[str, str],
+        federation_url: str,
+        target_relative_dir: Path,
+        is_dry_run: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """
     Sends a request to the federation endpoint to retrieve DRS object
@@ -432,21 +432,21 @@ def collect_metadata_for_file_item(
 
 
 def collect_metadata_for_analysis_drs_objects(
-    analysis_drs_federation_response: List[Dict[str, Any]],
-    federation_headers: Dict[str, str],
-    federation_url: str,
-    target_relative_dir_for_sample: Path,
-    is_dry_run: bool = False,
-    tqdm_position: int = 1,
+        analysis_drs_federation_response: List[Dict[str, Any]],
+        federation_headers: Dict[str, str],
+        federation_url: str,
+        target_relative_dir_for_sample: Path,
+        is_dry_run: bool = False,
+        tqdm_position: int = 1,
 ) -> tuple[List[Dict[str, Any]], bool]:
     collected_files_metadata = []
     any_sequence_variation_found_in_responses = False
 
     for fed_resp_item_for_analysis_drs in tqdm(
-        analysis_drs_federation_response,
-        desc=" Checking AnalysisDRS sources",
-        leave=False,
-        position=tqdm_position,
+            analysis_drs_federation_response,
+            desc=" Checking AnalysisDRS sources",
+            leave=False,
+            position=tqdm_position,
     ):
         analysis_drs_results = fed_resp_item_for_analysis_drs.get("results")
         location = fed_resp_item_for_analysis_drs.get("location", "unknown location")
@@ -458,8 +458,8 @@ def collect_metadata_for_analysis_drs_objects(
             continue
 
         if (
-            analysis_drs_results.get("metadata", {}).get("analysis_type")
-            != "sequence_variation"
+                analysis_drs_results.get("metadata", {}).get("analysis_type")
+                != "sequence_variation"
         ):
             logger.debug(
                 f"Skipping non-sequence variation AnalysisDRS object '{analysis_drs_results.get('name', 'N/A')}' from {location}."
@@ -531,8 +531,8 @@ def collect_metadata_for_analysis_drs_objects(
 
 
 def get_programs_in_genomics(
-    federation_url: str,
-    federation_headers: Dict[str, str],
+        federation_url: str,
+        federation_headers: Dict[str, str],
 ) -> List[str]:
     """
     Queries all federated genomics services for available program names.
@@ -570,10 +570,10 @@ def get_programs_in_genomics(
 
 
 def collect_all_variant_metadata(
-    program_sample_ids: List[str],
-    federation_headers: Dict[str, str],
-    federation_url: str,
-    is_dry_run: bool = False,
+        program_sample_ids: List[str],
+        federation_headers: Dict[str, str],
+        federation_url: str,
+        is_dry_run: bool = False,
 ):
     """
     Collects metadata for all provided program-sample IDs.
@@ -618,10 +618,10 @@ def collect_all_variant_metadata(
         f"Processing {len(valid_program_ids_to_process)} program-sample IDs for metadata collection."
     )
     for program_sample_id in tqdm(
-        valid_program_ids_to_process,
-        desc="Samples metadata scan",
-        unit="sample",
-        position=0,
+            valid_program_ids_to_process,
+            desc="Samples metadata scan",
+            unit="sample",
+            position=0,
     ):
         try:
             program_id, sample_id = program_sample_id.split("~", 1)
@@ -667,39 +667,44 @@ def collect_all_variant_metadata(
 
                         if analysis_drs_fed_resp:
                             relative_sample_files_dir = (
-                                Path(variants_output_parent_dir_name)
-                                / f"{program_id}"
+                                    Path(variants_output_parent_dir_name)
+                                    / f"{program_id}"
                             )
 
-                            analysis_obj_results = analysis_drs_fed_resp[0]['results']['id']
-                            analysis_metadata_dict[analysis_obj_results] = analysis_drs_fed_resp[0]['results']['metadata']
-                            analysis_metadata_dict[analysis_obj_results]["file_id"] = analysis_obj_results
-                            analysis_metadata_dict[analysis_obj_results]["program"] = analysis_drs_fed_resp[0]['results']['program']
-                            analysis_metadata_dict[analysis_obj_results]["reference_genome"] = \
-                            analysis_drs_fed_resp[0]['results']['reference_genome']
-                            for linked_obj in analysis_drs_fed_resp[0]['results'].get('contents'):
-                                if linked_obj['id'] not in ['analysis', 'index']:
-                                    try:
-                                        (analysis_metadata_dict[analysis_obj_results]['samples']
-                                         .append({
+                            for response in analysis_drs_fed_resp:
+                                if "results" in response:
+                                    analysis_obj_results = response['results']['id']
+                                    analysis_metadata_dict[analysis_obj_results] = response['results']['metadata']
+                                    analysis_metadata_dict[analysis_obj_results]["file_id"] = analysis_obj_results
+                                    analysis_metadata_dict[analysis_obj_results]["program"] = response['results'][
+                                        'program']
+                                    analysis_metadata_dict[analysis_obj_results]["reference_genome"] = \
+                                        response["results"]['reference_genome']
+                                    for linked_obj in response['results'].get('contents'):
+                                        if linked_obj['id'] not in ['analysis', 'index']:
+                                            try:
+                                                (analysis_metadata_dict[analysis_obj_results]['samples']
+                                                .append({
                                                     "submitter_sample_id": linked_obj['name'],
                                                     "analysis_sample_id": linked_obj['id'],
                                                     "experiment_id": linked_obj['drs_uri'][0].rsplit('/', 1)[-1]
                                                 }))
-                                    except KeyError as e:
-                                        analysis_metadata_dict[analysis_obj_results]['samples'] = \
-                                            [
-                                                {
-                                                    "submitter_sample_id": linked_obj['name'],
-                                                    "analysis_sample_id": linked_obj['id'],
-                                                    "experiment_id": linked_obj['drs_uri'][0].rsplit('/', 1)[-1]
-                                                }
-                                            ]
-                                else:
-                                    try:
-                                        analysis_metadata_dict[analysis_obj_results]['files'].append(linked_obj['drs_uri'][0].rsplit('/', 1)[-1])
-                                    except KeyError as e:
-                                        analysis_metadata_dict[analysis_obj_results]['files'] = [linked_obj['drs_uri'][0].rsplit('/', 1)[-1]]
+                                            except KeyError as e:
+                                                analysis_metadata_dict[analysis_obj_results]['samples'] = \
+                                                    [
+                                                        {
+                                                            "submitter_sample_id": linked_obj['name'],
+                                                            "analysis_sample_id": linked_obj['id'],
+                                                            "experiment_id": linked_obj['drs_uri'][0].rsplit('/', 1)[-1]
+                                                        }
+                                                    ]
+                                        else:
+                                            try:
+                                                analysis_metadata_dict[analysis_obj_results]['files'].append(
+                                                    linked_obj['drs_uri'][0].rsplit('/', 1)[-1])
+                                            except KeyError as e:
+                                                analysis_metadata_dict[analysis_obj_results]['files'] = [
+                                                    linked_obj['drs_uri'][0].rsplit('/', 1)[-1]]
 
                             files_meta, has_seq_var_in_obj = (
                                 collect_metadata_for_analysis_drs_objects(
@@ -789,7 +794,7 @@ def write_experiment_metadata_to_csv(
 
 
 def write_variant_metadata_to_file(
-    files_metadata_list: List[Dict[str, Any]], metadata_file_path: Path
+        files_metadata_list: List[Dict[str, Any]], metadata_file_path: Path
 ) -> None:
     try:
         metadata_file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -825,9 +830,9 @@ def write_variant_metadata_to_file(
 
 
 def download_files_from_collected_metadata(
-    files_metadata_list: List[Dict[str, Any]],
-    download_headers: Dict[str, str],
-    session_dir: Path,
+        files_metadata_list: List[Dict[str, Any]],
+        download_headers: Dict[str, str],
+        session_dir: Path,
 ) -> List[DownloadResult]:
     """
     For each metadata entry, this function:
@@ -861,11 +866,11 @@ def download_files_from_collected_metadata(
             )
             continue
         if not all(
-            [
-                meta_entry.get("download_url"),
-                filename,
-                meta_entry.get("target_output_dir"),
-            ]
+                [
+                    meta_entry.get("download_url"),
+                    filename,
+                    meta_entry.get("target_output_dir"),
+                ]
         ):
             error_msg = f"Incomplete metadata for '{filename}'. Skipping."
             logger.error(error_msg)
@@ -892,10 +897,10 @@ def download_files_from_collected_metadata(
     )
 
     for meta_entry in tqdm(
-        valid_metadata_to_process,
-        desc="Overall file processing",
-        unit="file",
-        position=0,
+            valid_metadata_to_process,
+            desc="Overall file processing",
+            unit="file",
+            position=0,
     ):
         download_url = meta_entry["download_url"]
         filename = meta_entry["filename"]
@@ -1046,12 +1051,12 @@ def get_download_session_dir(base_download_path_str: str = "candig_downloads") -
 
 
 def run_variant_download_pipeline(
-    program_sample_ids: Optional[List[str]],
-    federation_headers: Dict[str, str],
-    download_headers: Dict[str, str],
-    federation_url: str,
-    session_dir: Path,
-    is_dry_run: bool = False,
+        program_sample_ids: Optional[List[str]],
+        federation_headers: Dict[str, str],
+        download_headers: Dict[str, str],
+        federation_url: str,
+        session_dir: Path,
+        is_dry_run: bool = False,
 ) -> bool:
     """
     This function performs two main phases:
@@ -1080,7 +1085,8 @@ def run_variant_download_pipeline(
             federation_url=federation_url,
             is_dry_run=is_dry_run,
         )
-        write_experiment_metadata_to_csv(all_metadata[1]['experiment_metadata'], Path(session_dir, "experiment_data.csv"))
+        write_experiment_metadata_to_csv(all_metadata[1]['experiment_metadata'],
+                                         Path(session_dir, "experiment_data.csv"))
         write_experiment_metadata_to_csv(all_metadata[1]['analysis_metadata'],
                                          Path(session_dir, "analysis_data.csv"))
         newly_collected_metadata = all_metadata[0]
@@ -1134,7 +1140,7 @@ def run_variant_download_pipeline(
                 )
                 continue
             if not all(
-                [item.get("download_url"), filename, item.get("target_output_dir")]
+                    [item.get("download_url"), filename, item.get("target_output_dir")]
             ):
                 files_with_errors_in_meta += 1
                 print(f"  - Would skip {filename} due to incomplete metadata.")
@@ -1149,8 +1155,8 @@ def run_variant_download_pipeline(
                     target_path, expected_size, expected_checksums
                 )
                 if (
-                    verification_status == "MATCH_CHECKSUM"
-                    or verification_status == "MATCH_SIZE"
+                        verification_status == "MATCH_CHECKSUM"
+                        or verification_status == "MATCH_SIZE"
                 ):
                     files_would_skip_validated += 1
                     print(

--- a/src/client/download_helpers.py
+++ b/src/client/download_helpers.py
@@ -193,7 +193,10 @@ def execute_federation_call(
         )
         try:
             details = e.response.json()
-            print(f"Error details: {json.dumps(details, indent=2)}", file=sys.stderr)
+            logger.error(f"Error details: {json.dumps(details)}")
+            if "error" in details:
+                if details["error"] == "Key not authorised":
+                    logger.error(f"Either your token has expired or there is an issue with another node in the network. Please retry with a new token or use -r to resume an interrupted download. Federated node status can be checked on the summary page.")
         except json.JSONDecodeError:
             print(f"Response body: {e.response.text[:500]}...", file=sys.stderr)
         return None

--- a/src/client/download_helpers.py
+++ b/src/client/download_helpers.py
@@ -25,6 +25,13 @@ class DownloadResult:
     status: Optional[str] = None
     message: Optional[str] = None
 
+    def as_dict(self):
+        return {"success": self.success,
+                "file_path": self.file_path,
+                "error": self.error,
+                "status": self.status,
+                "message": self.message}
+
 
 # --- Checksum Utilities ---
 def calculate_checksum(file_path: Path, hash_type: str = "md5") -> Optional[str]:
@@ -593,7 +600,7 @@ def collect_all_variant_metadata(
             if program_id in genomics_programs:
                 valid_program_ids_to_process.append(ps_id)
             else:
-                logger.info(
+                logger.debug(
                     f"Skipping '{ps_id}': program '{program_id}' not in fetched genomics programs list."
                 )
         except ValueError:
@@ -1131,6 +1138,11 @@ def run_variant_download_pipeline(
         download_headers=download_headers,
         session_dir=session_dir,
     )
+
+    with open(variant_metadata_log_path, "a") as variant_log:
+        for result in download_results:
+            json.dump(result.as_dict(), variant_log)
+            variant_log.write("\n")
 
     succeeded_new_downloads = sum(
         1 for r in download_results if r.status == "DOWNLOADED_SUCCESS"

--- a/src/client/download_helpers.py
+++ b/src/client/download_helpers.py
@@ -643,6 +643,7 @@ def collect_all_variant_metadata(
                 exp_loc = fed_resp_item_exp.get("location", "N/A")
                 experiment_results_list = fed_resp_item_exp.get("results", [])
 
+                # Extract experiment object metadata
                 for experiment_obj in experiment_results_list:
                     experiment_metadata_dict[program_sample_id] = experiment_obj.get("metadata")
                     experiment_metadata_dict[program_sample_id]["experiment_id"] = experiment_obj.get('id')
@@ -671,6 +672,7 @@ def collect_all_variant_metadata(
                                     / f"{program_id}"
                             )
 
+                            # Extract analysis object metadata
                             for response in analysis_drs_fed_resp:
                                 if "results" in response:
                                     analysis_obj_results = response['results']['id']
@@ -1219,11 +1221,6 @@ def run_variant_download_pipeline(
         download_headers=download_headers,
         session_dir=session_dir,
     )
-
-    with open(variant_metadata_log_path, "a") as variant_log:
-        for result in download_results:
-            json.dump(result.as_dict(), variant_log)
-            variant_log.write("\n")
 
     succeeded_new_downloads = sum(
         1 for r in download_results if r.status == "DOWNLOADED_SUCCESS"

--- a/src/client/download_helpers.py
+++ b/src/client/download_helpers.py
@@ -653,7 +653,7 @@ def collect_all_variant_metadata(
                         if analysis_drs_fed_resp:
                             relative_sample_files_dir = (
                                 Path(variants_output_parent_dir_name)
-                                / f"{program_id}-{sample_id}"
+                                / f"{program_id}"
                             )
 
                             files_meta, has_seq_var_in_obj = (

--- a/src/client/download_helpers.py
+++ b/src/client/download_helpers.py
@@ -2,6 +2,8 @@ import hashlib
 import json
 import logging
 import sys
+import csv
+import pandas as pd
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -572,7 +574,7 @@ def collect_all_variant_metadata(
     federation_headers: Dict[str, str],
     federation_url: str,
     is_dry_run: bool = False,
-) -> List[Dict[str, Any]]:
+):
     """
     Collects metadata for all provided program-sample IDs.
 
@@ -594,6 +596,8 @@ def collect_all_variant_metadata(
     variants_output_parent_dir_name = "variant_data"
 
     valid_program_ids_to_process = []
+    experiment_metadata_dict = {}
+    analysis_metadata_dict = {}
     for ps_id in program_sample_ids:
         try:
             program_id, _ = ps_id.split("~", 1)
@@ -640,6 +644,10 @@ def collect_all_variant_metadata(
                 experiment_results_list = fed_resp_item_exp.get("results", [])
 
                 for experiment_obj in experiment_results_list:
+                    experiment_metadata_dict[program_sample_id] = experiment_obj.get("metadata")
+                    experiment_metadata_dict[program_sample_id]["experiment_id"] = experiment_obj.get('id')
+                    experiment_metadata_dict[program_sample_id]["program_id"] = experiment_obj.get('program')
+                    experiment_metadata_dict[program_sample_id]["submitter_sample_id"] = experiment_obj.get('name')
                     for content_item in experiment_obj.get("contents", []):
                         analysis_drs_name = content_item.get("name")
                         if not analysis_drs_name:
@@ -662,6 +670,36 @@ def collect_all_variant_metadata(
                                 Path(variants_output_parent_dir_name)
                                 / f"{program_id}"
                             )
+
+                            analysis_obj_results = analysis_drs_fed_resp[0]['results']['id']
+                            analysis_metadata_dict[analysis_obj_results] = analysis_drs_fed_resp[0]['results']['metadata']
+                            analysis_metadata_dict[analysis_obj_results]["file_id"] = analysis_obj_results
+                            analysis_metadata_dict[analysis_obj_results]["program"] = analysis_drs_fed_resp[0]['results']['program']
+                            analysis_metadata_dict[analysis_obj_results]["reference_genome"] = \
+                            analysis_drs_fed_resp[0]['results']['reference_genome']
+                            for linked_obj in analysis_drs_fed_resp[0]['results'].get('contents'):
+                                if linked_obj['id'] not in ['analysis', 'index']:
+                                    try:
+                                        (analysis_metadata_dict[analysis_obj_results]['samples']
+                                         .append({
+                                                    "submitter_sample_id": linked_obj['name'],
+                                                    "analysis_sample_id": linked_obj['id'],
+                                                    "experiment_id": linked_obj['drs_uri'][0].rsplit('/', 1)[-1]
+                                                }))
+                                    except KeyError as e:
+                                        analysis_metadata_dict[analysis_obj_results]['samples'] = \
+                                            [
+                                                {
+                                                    "submitter_sample_id": linked_obj['name'],
+                                                    "analysis_sample_id": linked_obj['id'],
+                                                    "experiment_id": linked_obj['drs_uri'][0].rsplit('/', 1)[-1]
+                                                }
+                                            ]
+                                else:
+                                    try:
+                                        analysis_metadata_dict[analysis_obj_results]['files'].append(linked_obj['drs_uri'][0].rsplit('/', 1)[-1])
+                                    except KeyError as e:
+                                        analysis_metadata_dict[analysis_obj_results]['files'] = [linked_obj['drs_uri'][0].rsplit('/', 1)[-1]]
 
                             files_meta, has_seq_var_in_obj = (
                                 collect_metadata_for_analysis_drs_objects(
@@ -699,6 +737,8 @@ def collect_all_variant_metadata(
                 f"No sequence variation data found for sample {program_sample_id}."
             )
 
+    all_exp_metadata = {"experiment_metadata": experiment_metadata_dict,
+                        "analysis_metadata": analysis_metadata_dict}
     final_unique_metadata_list = []
     seen_keys_final = set()
     for meta_item in all_files_metadata_accumulator:
@@ -714,10 +754,41 @@ def collect_all_variant_metadata(
         else:
             final_unique_metadata_list.append(meta_item)
 
-    return final_unique_metadata_list
+    return final_unique_metadata_list, all_exp_metadata
 
 
-def write_metadata_to_file(
+def write_experiment_metadata_to_csv(
+        experiment_metadata: Dict, metadata_file_path: Path
+) -> None:
+    try:
+        metadata_file_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.error(
+            f"Could not create parent directory for metadata file {metadata_file_path}: {e}"
+        )
+        return
+
+    if not experiment_metadata:
+        logger.info(f"No new metadata entries to append to {metadata_file_path}.")
+        try:
+            with open(metadata_file_path, "a") as f:
+                pass
+        except IOError as e:
+            logger.error(
+                f"Could not ensure metadata file {metadata_file_path} exists: {e}"
+            )
+        return
+    try:
+        df = pd.DataFrame.from_dict(experiment_metadata, orient="index")
+        df.to_csv(metadata_file_path, index=False)
+        logger.debug(
+            f"Successfully wrote experiment metadata entries to {metadata_file_path}"
+        )
+    except IOError as e:
+        logger.error(f"Failed to append metadata to {metadata_file_path}: {e}")
+
+
+def write_variant_metadata_to_file(
     files_metadata_list: List[Dict[str, Any]], metadata_file_path: Path
 ) -> None:
     try:
@@ -1003,14 +1074,18 @@ def run_variant_download_pipeline(
         logger.debug(
             f"PHASE 1: Collecting new metadata for {len(program_sample_ids)} program-sample ID(s)..."
         )
-        newly_collected_metadata = collect_all_variant_metadata(
+        all_metadata = collect_all_variant_metadata(
             program_sample_ids=program_sample_ids,
             federation_headers=federation_headers,
             federation_url=federation_url,
             is_dry_run=is_dry_run,
         )
+        write_experiment_metadata_to_csv(all_metadata[1]['experiment_metadata'], Path(session_dir, "experiment_data.csv"))
+        write_experiment_metadata_to_csv(all_metadata[1]['analysis_metadata'],
+                                         Path(session_dir, "analysis_data.csv"))
+        newly_collected_metadata = all_metadata[0]
         if newly_collected_metadata:
-            write_metadata_to_file(
+            write_variant_metadata_to_file(
                 files_metadata_list=newly_collected_metadata,
                 metadata_file_path=variant_metadata_log_path,
             )

--- a/src/client/main.py
+++ b/src/client/main.py
@@ -3,17 +3,14 @@ import logging
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional
-from datetime import datetime
 
 from client import auth
 from client import clinical_helpers
 from client import config
 from client import download_helpers
 from client import genomics_helpers
-from colorama import Fore, Style, init
 from tqdm import tqdm
 
-init()
 logger = logging.getLogger(__name__)
 
 

--- a/src/client/main.py
+++ b/src/client/main.py
@@ -39,7 +39,7 @@ def setup_logging(session_dir: Path, log_level: int = config.LOG_LEVEL) -> None:
 
 
 # --- Helper : Session Setup ---
-def _setup_session_download(resume_path_str: Optional[str]) -> Path:
+def _setup_session_download(log_level, resume_path_str: Optional[str]) -> Path:
     if resume_path_str:
         session_dir = Path(resume_path_str)
         if not session_dir.is_dir():
@@ -50,7 +50,8 @@ def _setup_session_download(resume_path_str: Optional[str]) -> Path:
         session_dir = download_helpers.get_download_session_dir()
         print(f"New download folder created at: {session_dir}")
 
-    run_log_file_path = session_dir / "run_command.log"
+    setup_logging(session_dir, log_level)
+    run_log_file_path = session_dir / "download-client.log"
     # Filter out token from argv
     filtered_argv = [
         arg
@@ -59,8 +60,7 @@ def _setup_session_download(resume_path_str: Optional[str]) -> Path:
         and (i == 0 or sys.argv[i - 1] != "--token")
         and not arg.startswith("--token=")
     ]
-    with open(run_log_file_path, "w") as f:
-        f.write(f"Run command: {' '.join(filtered_argv)}\n")
+    logger.info(f"Run command: {' '.join(filtered_argv)}\n")
     logger.info(f"Run command details saved to {run_log_file_path}")
     return session_dir
 
@@ -257,10 +257,10 @@ def main():
     #   3. Download and process clinical data (if requested)
     #   4. Download and process variant data (if requested)
     # ===================================================
-    session_dir = _setup_session_download(args.resume)
+    session_dir = _setup_session_download(args.log_level, args.resume)
 
     # ===== Setup Logging =====
-    setup_logging(session_dir, args.log_level)
+
 
     if args.dry_run:
         logger.warning("DRY RUN MODE ENABLED")

--- a/src/client/main.py
+++ b/src/client/main.py
@@ -261,7 +261,6 @@ def main():
 
     # ===== Setup Logging =====
 
-
     if args.dry_run:
         logger.warning("DRY RUN MODE ENABLED")
 
@@ -306,6 +305,11 @@ def main():
 
     if args.gene_id and args.coord:
         parser.error("Cannot use both --gene-id and --coord. Exiting.")
+
+    if args.variant and not (args.gene_id or args.coord):
+        parser.error(
+            "When using --variant, you must specify either --gene-id or --coord."
+        )
     
     if args.variant and args.dry_run and not (args.gene_id or args.coord):
         parser.error(

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 1
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 
 [[package]]
 name = "anyio"
@@ -22,8 +27,8 @@ name = "candigv2-download-client"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "colorama" },
     { name = "httpx" },
+    { name = "pandas" },
     { name = "tqdm" },
 ]
 
@@ -36,8 +41,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "colorama" },
     { name = "httpx" },
+    { name = "pandas" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-dependency", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -68,7 +73,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749 }
 wheels = [
@@ -131,12 +136,122 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3e/ed6db5be21ce87955c0cbd3009f2803f59fa08df21b5df06862e2d8e2bdd/numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb", size = 21165245 },
+    { url = "https://files.pythonhosted.org/packages/22/c2/4b9221495b2a132cc9d2eb862e21d42a009f5a60e45fc44b00118c174bff/numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90", size = 14360048 },
+    { url = "https://files.pythonhosted.org/packages/fd/77/dc2fcfc66943c6410e2bf598062f5959372735ffda175b39906d54f02349/numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:37e990a01ae6ec7fe7fa1c26c55ecb672dd98b19c3d0e1d1f326fa13cb38d163", size = 5340542 },
+    { url = "https://files.pythonhosted.org/packages/7a/4f/1cb5fdc353a5f5cc7feb692db9b8ec2c3d6405453f982435efc52561df58/numpy-2.2.6-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:5a6429d4be8ca66d889b7cf70f536a397dc45ba6faeb5f8c5427935d9592e9cf", size = 6878301 },
+    { url = "https://files.pythonhosted.org/packages/eb/17/96a3acd228cec142fcb8723bd3cc39c2a474f7dcf0a5d16731980bcafa95/numpy-2.2.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efd28d4e9cd7d7a8d39074a4d44c63eda73401580c5c76acda2ce969e0a38e83", size = 14297320 },
+    { url = "https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915", size = 16801050 },
+    { url = "https://files.pythonhosted.org/packages/07/b6/89d837eddef52b3d0cec5c6ba0456c1bf1b9ef6a6672fc2b7873c3ec4e2e/numpy-2.2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74d4531beb257d2c3f4b261bfb0fc09e0f9ebb8842d82a7b4209415896adc680", size = 15807034 },
+    { url = "https://files.pythonhosted.org/packages/01/c8/dc6ae86e3c61cfec1f178e5c9f7858584049b6093f843bca541f94120920/numpy-2.2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8fc377d995680230e83241d8a96def29f204b5782f371c532579b4f20607a289", size = 18614185 },
+    { url = "https://files.pythonhosted.org/packages/5b/c5/0064b1b7e7c89137b471ccec1fd2282fceaae0ab3a9550f2568782d80357/numpy-2.2.6-cp310-cp310-win32.whl", hash = "sha256:b093dd74e50a8cba3e873868d9e93a85b78e0daf2e98c6797566ad8044e8363d", size = 6527149 },
+    { url = "https://files.pythonhosted.org/packages/a3/dd/4b822569d6b96c39d1215dbae0582fd99954dcbcf0c1a13c61783feaca3f/numpy-2.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:f0fd6321b839904e15c46e0d257fdd101dd7f530fe03fd6359c1ea63738703f3", size = 12904620 },
+    { url = "https://files.pythonhosted.org/packages/da/a8/4f83e2aa666a9fbf56d6118faaaf5f1974d456b1823fda0a176eff722839/numpy-2.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f9f1adb22318e121c5c69a09142811a201ef17ab257a1e66ca3025065b7f53ae", size = 21176963 },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/64e1affc7972decb74c9e29e5649fac940514910960ba25cd9af4488b66c/numpy-2.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c820a93b0255bc360f53eca31a0e676fd1101f673dda8da93454a12e23fc5f7a", size = 14406743 },
+    { url = "https://files.pythonhosted.org/packages/4a/9f/0121e375000b5e50ffdd8b25bf78d8e1a5aa4cca3f185d41265198c7b834/numpy-2.2.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3d70692235e759f260c3d837193090014aebdf026dfd167834bcba43e30c2a42", size = 5352616 },
+    { url = "https://files.pythonhosted.org/packages/31/0d/b48c405c91693635fbe2dcd7bc84a33a602add5f63286e024d3b6741411c/numpy-2.2.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:481b49095335f8eed42e39e8041327c05b0f6f4780488f61286ed3c01368d491", size = 6889579 },
+    { url = "https://files.pythonhosted.org/packages/52/b8/7f0554d49b565d0171eab6e99001846882000883998e7b7d9f0d98b1f934/numpy-2.2.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b64d8d4d17135e00c8e346e0a738deb17e754230d7e0810ac5012750bbd85a5a", size = 14312005 },
+    { url = "https://files.pythonhosted.org/packages/b3/dd/2238b898e51bd6d389b7389ffb20d7f4c10066d80351187ec8e303a5a475/numpy-2.2.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba10f8411898fc418a521833e014a77d3ca01c15b0c6cdcce6a0d2897e6dbbdf", size = 16821570 },
+    { url = "https://files.pythonhosted.org/packages/83/6c/44d0325722cf644f191042bf47eedad61c1e6df2432ed65cbe28509d404e/numpy-2.2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd48227a919f1bafbdda0583705e547892342c26fb127219d60a5c36882609d1", size = 15818548 },
+    { url = "https://files.pythonhosted.org/packages/ae/9d/81e8216030ce66be25279098789b665d49ff19eef08bfa8cb96d4957f422/numpy-2.2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9551a499bf125c1d4f9e250377c1ee2eddd02e01eac6644c080162c0c51778ab", size = 18620521 },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/e19617b9530b031db51b0926eed5345ce8ddc669bb3bc0044b23e275ebe8/numpy-2.2.6-cp311-cp311-win32.whl", hash = "sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47", size = 6525866 },
+    { url = "https://files.pythonhosted.org/packages/31/0a/f354fb7176b81747d870f7991dc763e157a934c717b67b58456bc63da3df/numpy-2.2.6-cp311-cp311-win_amd64.whl", hash = "sha256:e8213002e427c69c45a52bbd94163084025f533a55a59d6f9c5b820774ef3303", size = 12907455 },
+    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348 },
+    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362 },
+    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103 },
+    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382 },
+    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462 },
+    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618 },
+    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511 },
+    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783 },
+    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506 },
+    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190 },
+    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828 },
+    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006 },
+    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765 },
+    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736 },
+    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719 },
+    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072 },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213 },
+    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632 },
+    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532 },
+    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885 },
+    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467 },
+    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144 },
+    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217 },
+    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014 },
+    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935 },
+    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122 },
+    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143 },
+    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260 },
+    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225 },
+    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374 },
+    { url = "https://files.pythonhosted.org/packages/9e/3b/d94a75f4dbf1ef5d321523ecac21ef23a3cd2ac8b78ae2aac40873590229/numpy-2.2.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0b605b275d7bd0c640cad4e5d30fa701a8d59302e127e5f79138ad62762c3e3d", size = 21040391 },
+    { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754 },
+    { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476 },
+    { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666 },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
+]
+
+[[package]]
+name = "pandas"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/51/48f713c4c728d7c55ef7444ba5ea027c26998d96d1a40953b346438602fc/pandas-2.3.0.tar.gz", hash = "sha256:34600ab34ebf1131a7613a260a61dbe8b62c188ec0ea4c296da7c9a06b004133", size = 4484490 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/2d/df6b98c736ba51b8eaa71229e8fcd91233a831ec00ab520e1e23090cc072/pandas-2.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:625466edd01d43b75b1883a64d859168e4556261a5035b32f9d743b67ef44634", size = 11527531 },
+    { url = "https://files.pythonhosted.org/packages/77/1c/3f8c331d223f86ba1d0ed7d3ed7fcf1501c6f250882489cc820d2567ddbf/pandas-2.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a6872d695c896f00df46b71648eea332279ef4077a409e2fe94220208b6bb675", size = 10774764 },
+    { url = "https://files.pythonhosted.org/packages/1b/45/d2599400fad7fe06b849bd40b52c65684bc88fbe5f0a474d0513d057a377/pandas-2.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4dd97c19bd06bc557ad787a15b6489d2614ddaab5d104a0310eb314c724b2d2", size = 11711963 },
+    { url = "https://files.pythonhosted.org/packages/66/f8/5508bc45e994e698dbc93607ee6b9b6eb67df978dc10ee2b09df80103d9e/pandas-2.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:034abd6f3db8b9880aaee98f4f5d4dbec7c4829938463ec046517220b2f8574e", size = 12349446 },
+    { url = "https://files.pythonhosted.org/packages/f7/fc/17851e1b1ea0c8456ba90a2f514c35134dd56d981cf30ccdc501a0adeac4/pandas-2.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:23c2b2dc5213810208ca0b80b8666670eb4660bbfd9d45f58592cc4ddcfd62e1", size = 12920002 },
+    { url = "https://files.pythonhosted.org/packages/a1/9b/8743be105989c81fa33f8e2a4e9822ac0ad4aaf812c00fee6bb09fc814f9/pandas-2.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:39ff73ec07be5e90330cc6ff5705c651ace83374189dcdcb46e6ff54b4a72cd6", size = 13651218 },
+    { url = "https://files.pythonhosted.org/packages/26/fa/8eeb2353f6d40974a6a9fd4081ad1700e2386cf4264a8f28542fd10b3e38/pandas-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:40cecc4ea5abd2921682b57532baea5588cc5f80f0231c624056b146887274d2", size = 11082485 },
+    { url = "https://files.pythonhosted.org/packages/96/1e/ba313812a699fe37bf62e6194265a4621be11833f5fce46d9eae22acb5d7/pandas-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8adff9f138fc614347ff33812046787f7d43b3cef7c0f0171b3340cae333f6ca", size = 11551836 },
+    { url = "https://files.pythonhosted.org/packages/1b/cc/0af9c07f8d714ea563b12383a7e5bde9479cf32413ee2f346a9c5a801f22/pandas-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e5f08eb9a445d07720776df6e641975665c9ea12c9d8a331e0f6890f2dcd76ef", size = 10807977 },
+    { url = "https://files.pythonhosted.org/packages/ee/3e/8c0fb7e2cf4a55198466ced1ca6a9054ae3b7e7630df7757031df10001fd/pandas-2.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa35c266c8cd1a67d75971a1912b185b492d257092bdd2709bbdebe574ed228d", size = 11788230 },
+    { url = "https://files.pythonhosted.org/packages/14/22/b493ec614582307faf3f94989be0f7f0a71932ed6f56c9a80c0bb4a3b51e/pandas-2.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14a0cc77b0f089d2d2ffe3007db58f170dae9b9f54e569b299db871a3ab5bf46", size = 12370423 },
+    { url = "https://files.pythonhosted.org/packages/9f/74/b012addb34cda5ce855218a37b258c4e056a0b9b334d116e518d72638737/pandas-2.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c06f6f144ad0a1bf84699aeea7eff6068ca5c63ceb404798198af7eb86082e33", size = 12990594 },
+    { url = "https://files.pythonhosted.org/packages/95/81/b310e60d033ab64b08e66c635b94076488f0b6ce6a674379dd5b224fc51c/pandas-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ed16339bc354a73e0a609df36d256672c7d296f3f767ac07257801aa064ff73c", size = 13745952 },
+    { url = "https://files.pythonhosted.org/packages/25/ac/f6ee5250a8881b55bd3aecde9b8cfddea2f2b43e3588bca68a4e9aaf46c8/pandas-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:fa07e138b3f6c04addfeaf56cc7fdb96c3b68a3fe5e5401251f231fce40a0d7a", size = 11094534 },
+    { url = "https://files.pythonhosted.org/packages/94/46/24192607058dd607dbfacdd060a2370f6afb19c2ccb617406469b9aeb8e7/pandas-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2eb4728a18dcd2908c7fccf74a982e241b467d178724545a48d0caf534b38ebf", size = 11573865 },
+    { url = "https://files.pythonhosted.org/packages/9f/cc/ae8ea3b800757a70c9fdccc68b67dc0280a6e814efcf74e4211fd5dea1ca/pandas-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b9d8c3187be7479ea5c3d30c32a5d73d62a621166675063b2edd21bc47614027", size = 10702154 },
+    { url = "https://files.pythonhosted.org/packages/d8/ba/a7883d7aab3d24c6540a2768f679e7414582cc389876d469b40ec749d78b/pandas-2.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ff730713d4c4f2f1c860e36c005c7cefc1c7c80c21c0688fd605aa43c9fcf09", size = 11262180 },
+    { url = "https://files.pythonhosted.org/packages/01/a5/931fc3ad333d9d87b10107d948d757d67ebcfc33b1988d5faccc39c6845c/pandas-2.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba24af48643b12ffe49b27065d3babd52702d95ab70f50e1b34f71ca703e2c0d", size = 11991493 },
+    { url = "https://files.pythonhosted.org/packages/d7/bf/0213986830a92d44d55153c1d69b509431a972eb73f204242988c4e66e86/pandas-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:404d681c698e3c8a40a61d0cd9412cc7364ab9a9cc6e144ae2992e11a2e77a20", size = 12470733 },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/21eb48a3a34a7d4bac982afc2c4eb5ab09f2d988bdf29d92ba9ae8e90a79/pandas-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6021910b086b3ca756755e86ddc64e0ddafd5e58e076c72cb1585162e5ad259b", size = 13212406 },
+    { url = "https://files.pythonhosted.org/packages/1f/d9/74017c4eec7a28892d8d6e31ae9de3baef71f5a5286e74e6b7aad7f8c837/pandas-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:094e271a15b579650ebf4c5155c05dcd2a14fd4fdd72cf4854b2f7ad31ea30be", size = 10976199 },
+    { url = "https://files.pythonhosted.org/packages/d3/57/5cb75a56a4842bbd0511c3d1c79186d8315b82dac802118322b2de1194fe/pandas-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2c7e2fc25f89a49a11599ec1e76821322439d90820108309bf42130d2f36c983", size = 11518913 },
+    { url = "https://files.pythonhosted.org/packages/05/01/0c8785610e465e4948a01a059562176e4c8088aa257e2e074db868f86d4e/pandas-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c6da97aeb6a6d233fb6b17986234cc723b396b50a3c6804776351994f2a658fd", size = 10655249 },
+    { url = "https://files.pythonhosted.org/packages/e8/6a/47fd7517cd8abe72a58706aab2b99e9438360d36dcdb052cf917b7bf3bdc/pandas-2.3.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb32dc743b52467d488e7a7c8039b821da2826a9ba4f85b89ea95274f863280f", size = 11328359 },
+    { url = "https://files.pythonhosted.org/packages/2a/b3/463bfe819ed60fb7e7ddffb4ae2ee04b887b3444feee6c19437b8f834837/pandas-2.3.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:213cd63c43263dbb522c1f8a7c9d072e25900f6975596f883f4bebd77295d4f3", size = 12024789 },
+    { url = "https://files.pythonhosted.org/packages/04/0c/e0704ccdb0ac40aeb3434d1c641c43d05f75c92e67525df39575ace35468/pandas-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1d2b33e68d0ce64e26a4acc2e72d747292084f4e8db4c847c6f5f6cbe56ed6d8", size = 12480734 },
+    { url = "https://files.pythonhosted.org/packages/e9/df/815d6583967001153bb27f5cf075653d69d51ad887ebbf4cfe1173a1ac58/pandas-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:430a63bae10b5086995db1b02694996336e5a8ac9a96b4200572b413dfdfccb9", size = 13223381 },
+    { url = "https://files.pythonhosted.org/packages/79/88/ca5973ed07b7f484c493e941dbff990861ca55291ff7ac67c815ce347395/pandas-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:4930255e28ff5545e2ca404637bcc56f031893142773b3468dc021c6c32a1390", size = 10970135 },
+    { url = "https://files.pythonhosted.org/packages/24/fb/0994c14d1f7909ce83f0b1fb27958135513c4f3f2528bde216180aa73bfc/pandas-2.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:f925f1ef673b4bd0271b1809b72b3270384f2b7d9d14a189b12b7fc02574d575", size = 12141356 },
+    { url = "https://files.pythonhosted.org/packages/9d/a2/9b903e5962134497ac4f8a96f862ee3081cb2506f69f8e4778ce3d9c9d82/pandas-2.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78ad363ddb873a631e92a3c063ade1ecfb34cae71e9a2be6ad100f875ac1042", size = 11474674 },
+    { url = "https://files.pythonhosted.org/packages/81/3a/3806d041bce032f8de44380f866059437fb79e36d6b22c82c187e65f765b/pandas-2.3.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:951805d146922aed8357e4cc5671b8b0b9be1027f0619cea132a9f3f65f2f09c", size = 11439876 },
+    { url = "https://files.pythonhosted.org/packages/15/aa/3fc3181d12b95da71f5c2537c3e3b3af6ab3a8c392ab41ebb766e0929bc6/pandas-2.3.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a881bc1309f3fce34696d07b00f13335c41f5f5a8770a33b09ebe23261cfc67", size = 11966182 },
+    { url = "https://files.pythonhosted.org/packages/37/e7/e12f2d9b0a2c4a2cc86e2aabff7ccfd24f03e597d770abfa2acd313ee46b/pandas-2.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e1991bbb96f4050b09b5f811253c4f3cf05ee89a589379aa36cd623f21a31d6f", size = 12547686 },
+    { url = "https://files.pythonhosted.org/packages/39/c2/646d2e93e0af70f4e5359d870a63584dacbc324b54d73e6b3267920ff117/pandas-2.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:bb3be958022198531eb7ec2008cfc78c5b1eed51af8600c6c5d9160d89d8d249", size = 13231847 },
 ]
 
 [[package]]
@@ -186,6 +301,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7e/3b/317cc04e77d707d338540ca67b619df8f247f3f4c9f40e67bf5ea503ad94/pytest-dependency-0.6.0.tar.gz", hash = "sha256:934b0e6a39d95995062c193f7eaeed8a8ffa06ff1bcef4b62b0dc74a708bacc1", size = 19499 }
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225 },
+]
+
+[[package]]
 name = "ruff"
 version = "0.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -217,6 +353,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
 ]
 
 [[package]]
@@ -286,4 +431,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af", size = 43839 },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839 },
 ]


### PR DESCRIPTION
This adds some functionality based on recent feedback:
* Saves all files into a single folder for the whole program, rather than by sample so that a file is only downloaded once
* Saves experiment and analysis metadata into files called `experiment.csv` and `analysis.csv` so users can match between files and clinical metadata
* moves the run command log into the overall download-client log, sets up the logger with the session dir so that things can be logged earlier