### PR TITLE
Add error reporting when federated node call doesn't succeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ candig-download [OUTPUT_TYPE] [FILTER]
     ```bash
     candig-download -a --program-id "MoHQ-CM-37" --token YOUR_TOKEN
     ```
+   
+    To specify multiple programs
+
+    ```bash
+    candig-download -a --program-id "MoHQ-CM-37" "POG" --token YOUR_TOKEN
+    ```
 
 3. **Fetch clinical data for donors with mutation in a gene ID with verbose logging:**
 

--- a/src/client/download_helpers.py
+++ b/src/client/download_helpers.py
@@ -172,7 +172,7 @@ def execute_federation_call(
     """
     service = payload.get("service", "unknown_service")
     path = payload.get("path", "N/A")
-    logger.debug(f"Sending request to federation service for path: {path}")
+    logger.debug(f"Sending request to federation service for path: {path} with payload {payload}")
 
     try:
         with httpx.Client(timeout=config.TIMEOUT) as client:
@@ -184,7 +184,7 @@ def execute_federation_call(
             for node in response.json():
                 try:
                     if 'failed' in node['message']:
-                        logger.warning(f"Potential failure contacting node {node['location']['name']}")
+                        logger.warning(f"Failure contacting node {node['location']['name']}")
                         logger.warning(f"Error message: {node['message']}")
                 except KeyError as e:
                     continue

--- a/src/client/download_helpers.py
+++ b/src/client/download_helpers.py
@@ -181,6 +181,13 @@ def execute_federation_call(
             logger.debug(
                 f"Request to {path} successful (Status: {response.status_code})"
             )
+            for node in response.json():
+                try:
+                    if 'failed' in node['message']:
+                        logger.warning(f"Potential failure contacting node {node['location']['name']}")
+                        logger.warning(f"Error message: {node['message']}")
+                except KeyError as e:
+                    continue
             return response.json()
     except httpx.HTTPStatusError as e:
         logger.error(


### PR DESCRIPTION
- Adds error logging for federated calls
- Adds to README for how to specify multiple program ids in a download request